### PR TITLE
include non-source files in installations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,9 @@
 name = 'otable'
 version = '0.0'
 dependencies = ['manuel', 'termtables']
+
+[tool.setuptools.packages.find]
+where = ['src']
+
+[tool.setuptools.package-data]
+otable = ['*.txt', '*.rst', 'py.typed']

--- a/src/otable/__init__.py
+++ b/src/otable/__init__.py
@@ -1,5 +1,7 @@
 """Table data types backed by objects."""
 
+__all__ = ('OTable', 'OColumn', 'ORow')
+
 from .ocolumn import OColumn  # noqa
 from .orow import ORow  # noqa
 from .otable import OTable  # noqa


### PR DESCRIPTION
We want to include various non-source files in installations, especially `py.typed` so mypy knows that type information is included when other projects use this project as a dependency.