### PR TITLE
add optional getters and setters to columns

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,0 @@
-[MESSAGES CONTROL]
-
-disable=
-    wrong-import-order,
-    too-many-arguments,

--- a/.pylintrc
+++ b/.pylintrc
@@ -2,3 +2,4 @@
 
 disable=
     wrong-import-order,
+    too-many-arguments,

--- a/README.rst
+++ b/README.rst
@@ -162,14 +162,62 @@ mutated.
 ├────────┼──────┼────────┤
 │ Tripod │ 3    │ Alice  │
 └────────┴──────┴────────┘
->>> table[2][2] = 'Charlie'
+>>> table[2][2] = 'Alice in Wonderland'
 >>> table
-┌────────┬──────┬─────────┐
-│ name   │ legs │ friend  │
-╞════════╪══════╪═════════╡
-│ Ralf   │ 4    │ Charlie │
-├────────┼──────┼─────────┤
-│ Simon  │ 0    │ Bob     │
-├────────┼──────┼─────────┤
-│ Tripod │ 3    │ Charlie │
-└────────┴──────┴─────────┘
+┌────────┬──────┬─────────────────────┐
+│ name   │ legs │ friend              │
+╞════════╪══════╪═════════════════════╡
+│ Ralf   │ 4    │ Alice in Wonderland │
+├────────┼──────┼─────────────────────┤
+│ Simon  │ 0    │ Bob                 │
+├────────┼──────┼─────────────────────┤
+│ Tripod │ 3    │ Alice in Wonderland │
+└────────┴──────┴─────────────────────┘
+
+.. code:python
+
+    # We need to put Alice's name back for cleanliness' sake in the following sections.
+    alice.name = 'Alice'
+
+
+Getter functions
+----------------
+
+We may want to represent a value in a table that is not accessible as an attribute on an
+object.  For example, we may want to represent the result of calling a function.  Getter
+functions provide that ability.
+
+For example, if we wanted to model animals having more than one friend, we could change
+the friend column definition to model that information as a list of friends.
+
+.. code:: python
+
+    friends = OColumn('friends', [[alice], [bob], [alice, bob]], attribute='name')
+
+That seems to make sense, but the containing table fails to render correctly with the
+following error::
+
+    AttributeError: 'list' object has no attribute 'name'
+
+That error makes sense because we told the column that it should look up the ``name``
+attribute on each object to find the column's value, but the objects are lists which do
+not have that attribute.  Instead of specifying an attribute, we can specify a function
+that will extract the value we need.
+
+.. code:: python
+
+    friend_getter = lambda friends: ','.join(friend.name for friend in friends)
+    friends = OColumn('friends', [[alice], [bob], [alice, bob]], getter=friend_getter)
+
+Now the table will render correctly.
+
+>>> OTable(columns=(names, legs, friends))
+┌────────┬──────┬───────────┐
+│ name   │ legs │ friends   │
+╞════════╪══════╪═══════════╡
+│ Ralf   │ 4    │ Alice     │
+├────────┼──────┼───────────┤
+│ Simon  │ 0    │ Bob       │
+├────────┼──────┼───────────┤
+│ Tripod │ 3    │ Alice,Bob │
+└────────┴──────┴───────────┘

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,6 @@ where = ['src']
 
 [tool.setuptools.package-data]
 otable = ['*.txt', '*.rst', 'py.typed']
+
+[tool.pylint.'MESSAGES CONTROL']
+disable = ['wrong-import-order', 'too-many-arguments']

--- a/src/otable/ocolumn.py
+++ b/src/otable/ocolumn.py
@@ -4,8 +4,6 @@ import collections.abc
 from operator import attrgetter
 from typing import Any, Callable, Iterable, Sequence, TypeVar, cast, overload
 
-__all__ = ['OColumn']
-
 
 def attrsetter(name: str) -> Callable[[Any, Any], None]:
     """Create an attribute setter; analogous to operator.attrgetter."""

--- a/src/otable/ocolumn.py
+++ b/src/otable/ocolumn.py
@@ -29,7 +29,7 @@ class OColumn(collections.abc.MutableSequence[T]):
     # The above is because pylint erroneously reports that the "getter" and "setter"
     # attributes are not listed in the __slots__ definition below, but that's not true.
 
-    __slots__ = ('objects', 'name', 'getter', 'setter')
+    __slots__ = ('name', 'objects', 'getter', 'setter')
 
     objects: list[T]
     name: str

--- a/src/otable/orow.py
+++ b/src/otable/orow.py
@@ -29,9 +29,9 @@ class ORow(collections.abc.MutableSequence[T]):
         self.objects = tuple(objects)
 
     @property
-    def names(self) -> list[str]:
+    def names(self) -> Sequence[str]:
         """Fetch the column names."""
-        return [column.name for column in self.columns]
+        return tuple(column.name for column in self.columns)
 
     @overload
     def __getitem__(self, item: int) -> T:  # pragma: nocover

--- a/src/otable/orow.py
+++ b/src/otable/orow.py
@@ -4,6 +4,7 @@ import collections.abc
 from .ocolumn import OColumn
 from typing import Any, Iterable, Sequence, TypeVar, cast, overload
 
+# pylint: disable=fixme
 # XXX The typing of ORow is not correct.  As written, a row can only contain one type at
 # a time and that is not actually the case.
 T = TypeVar('T')

--- a/src/otable/orow.py
+++ b/src/otable/orow.py
@@ -53,10 +53,10 @@ class ORow(collections.abc.MutableSequence[T]):
         return cast(T, getter(obj))
 
     def __getattr__(self, name: str) -> T:
-        if name in self.names:
-            index = self.names.index(name)
-            return self[index]
-        raise AttributeError
+        if name not in self.names:
+            raise AttributeError
+        index = self.names.index(name)
+        return self[index]
 
     @overload
     def __setitem__(self, item: int, value: T) -> None:  # pragma: nocover

--- a/src/otable/orow.py
+++ b/src/otable/orow.py
@@ -4,6 +4,8 @@ import collections.abc
 from .ocolumn import OColumn
 from typing import Any, Iterable, Sequence, TypeVar, cast, overload
 
+# XXX The typing of ORow is not correct.  As written, a row can only contain one type at
+# a time and that is not actually the case.
 T = TypeVar('T')
 
 

--- a/src/otable/otable.py
+++ b/src/otable/otable.py
@@ -43,9 +43,7 @@ class OTable(collections.abc.Sequence[T]):
         if isinstance(item, slice):
             raise ValueError('slicing tables is not supported')
         objects = [column.objects[item] for column in self.columns]
-        names = [column.name for column in self.columns]
-        attributes = [column.attribute for column in self.columns]
-        return ORow(names, objects, attributes)
+        return ORow(self.columns, objects)
 
     def __len__(self) -> int:
         return len(self.columns[0])

--- a/tests/unit/test_ocolumn.py
+++ b/tests/unit/test_ocolumn.py
@@ -29,7 +29,7 @@ class TestOColumn(unittest.TestCase):
 
     def test_creation(self):
         """Creating an OColumn instance works."""
-        OColumn([], 'attribute')
+        OColumn('attribute', [])
 
     def test_len(self):
         """The length of the column reflects the length of the underlying sequence."""

--- a/tests/unit/test_orow.py
+++ b/tests/unit/test_orow.py
@@ -29,7 +29,8 @@ class TestORow(unittest.TestCase):
 
     def test_creation(self):
         """Creating an ORow instance works."""
-        ORow(['name', 'legs'], [dog, dog], ['name', 'legs'])
+        columns = [OColumn('name', objects=animals), OColumn('legs', objects=animals)]
+        ORow(columns, [dog, dog])
 
     def test_len(self):
         """The length of the row reflects the width of the table."""
@@ -40,31 +41,36 @@ class TestORow(unittest.TestCase):
 
     def test_get_slice(self):
         """Reading a slice of a row is not supported."""
-        row = ORow(['name', 'legs'], [dog, dog], ['name', 'legs'])
+        columns = [OColumn('name', objects=animals), OColumn('legs', objects=animals)]
+        row = ORow(columns, [dog, dog])
         with self.assertRaisesRegex(ValueError, 'slicing rows is not supported'):
             row[1:2]
 
     def test_set_slice(self):
         """Writing a slice of a row is not supported."""
-        row = ORow(['name', 'legs'], [dog, dog], ['name', 'legs'])
+        columns = [OColumn('name', objects=animals), OColumn('legs', objects=animals)]
+        row = ORow(columns, [dog, dog])
         with self.assertRaisesRegex(ValueError, 'slicing rows is not supported'):
             row[1:2] = None
 
     def test_del(self):
         """Deleting a slice of a row is not supported."""
-        row = ORow(['name', 'legs'], [dog, dog], ['name', 'legs'])
+        columns = [OColumn('name', objects=animals), OColumn('legs', objects=animals)]
+        row = ORow(columns, [dog, dog])
         error = (RuntimeError, 'deleting from rows is not supported')
         with self.assertRaisesRegex(*error):
             del row[1:2]
 
     def test_bad_name(self):
         """Accessing an attribute that does not exist generates an AttributeError."""
-        row = ORow(['name', 'legs'], [dog, dog], ['name', 'legs'])
+        columns = [OColumn('name', objects=animals), OColumn('legs', objects=animals)]
+        row = ORow(columns, [dog, dog])
         with self.assertRaises(AttributeError):
             row.does_not_exist
 
     def test_insert(self):
         """Inserting into a row is not permitted."""
-        row = ORow(['name', 'legs'], [dog, dog], ['name', 'legs'])
+        columns = [OColumn('name', objects=animals), OColumn('legs', objects=animals)]
+        row = ORow(columns, [dog, dog])
         with self.assertRaisesRegex(RuntimeError, 'inserts are not allowed'):
             row.insert(0, 'Jennifer')


### PR DESCRIPTION
This change makes it so that OColumns can expose computed values instead of only simple attributes on objects.